### PR TITLE
fix: default mapping throws error if already used

### DIFF
--- a/plugin/tabmode.vim
+++ b/plugin/tabmode.vim
@@ -4,7 +4,9 @@ endif
 let g:loaded_tabmode = 1
 
 nnoremap <silent> <unique> <Plug>(TabmodeEnter) <Cmd>lua require('tabmode')()<CR>
-nmap <silent> <unique> <leader><Tab> <Plug>(TabmodeEnter)
+if mapcheck("<leader><Tab>") == ""
+	nmap <silent> <unique> <leader><Tab> <Plug>(TabmodeEnter)
+endif
 
 if !exists(':TabmodeEnter')
 	command! TabmodeEnter lua require('tabmode')()

--- a/plugin/tabmode.vim
+++ b/plugin/tabmode.vim
@@ -4,7 +4,7 @@ endif
 let g:loaded_tabmode = 1
 
 nnoremap <silent> <unique> <Plug>(TabmodeEnter) <Cmd>lua require('tabmode')()<CR>
-if mapcheck("<leader><Tab>") == ""
+if mapcheck('<leader><Tab>') == ''
 	nmap <silent> <unique> <leader><Tab> <Plug>(TabmodeEnter)
 endif
 


### PR DESCRIPTION
If there already is a `<leader><tab>` mapping there is an error thrown on startup.